### PR TITLE
feat: delete email queues with status in sent and error on scheduler

### DIFF
--- a/medtech_bpa/hooks.py
+++ b/medtech_bpa/hooks.py
@@ -90,13 +90,13 @@ app_license = "MIT"
 # Scheduled Tasks
 # ---------------
 
-# scheduler_events = {
+scheduler_events = {
 # 	"all": [
 # 		"medtech_bpa.tasks.all"
 # 	],
-# 	"daily": [
-# 		"medtech_bpa.tasks.daily"
-# 	],
+	"daily": [
+		"medtech_bpa.medtech_bpa.utils.delete_email_queues"
+	],
 # 	"hourly": [
 # 		"medtech_bpa.tasks.hourly"
 # 	],
@@ -106,7 +106,7 @@ app_license = "MIT"
 # 	"monthly": [
 # 		"medtech_bpa.tasks.monthly"
 # 	]
-# }
+}
 
 # Testing
 # -------

--- a/medtech_bpa/medtech_bpa/utils.py
+++ b/medtech_bpa/medtech_bpa/utils.py
@@ -1,0 +1,16 @@
+import frappe
+
+def delete_email_queues():
+    '''method deletes email queues whose status is in Sent and/or Error'''
+    #added tuesday (1) in the condition for testing purposes only! should remove once confirmed
+    if not frappe.utils.get_datetime().weekday() in [0, 1, 2, 4]:
+        return
+    deletable_email_queues_tuple = tuple(frappe.db.get_list('Email Queue', {'status':['in',['Sent', 'Error']]}, pluck = 'name'))
+    frappe.db.sql('''
+    DELETE FROM
+        `tabEmail Queue`
+    WHERE
+        name
+    IN
+        %(deletable_email_queues)s;
+    ''', values={'deletable_email_queues':deletable_email_queues_tuple})


### PR DESCRIPTION
## Feature Description
Delete Email Queues that has their status in Sent and/or Error on daily scheduler on Monday, Wednesday and Friday