### PR TITLE
Removed HTML tags from Consignee Address

### DIFF
--- a/medtech_bpa/medtech_bpa/custom_scripts/delivery_note/delivery_note.js
+++ b/medtech_bpa/medtech_bpa/custom_scripts/delivery_note/delivery_note.js
@@ -459,36 +459,41 @@ frappe.ui.form.on('Delivery Note', {
         frm.refresh_field("items")
     },
     
-    onload: function(frm) {
-        if (!frm.doc.items || frm.doc.items.length === 0) return;
+   onload: function(frm) {
+    if (!frm.doc.items || frm.doc.items.length === 0) return;
 
-        const sales_orders = frm.doc.items
-            .filter(item => item.against_sales_order)
-            .map(item => item.against_sales_order);
+    const sales_orders = frm.doc.items
+        .filter(item => item.against_sales_order)
+        .map(item => item.against_sales_order);
 
-        if (sales_orders.length === 0) return;
+    if (sales_orders.length === 0) return;
 
-        // Use the first available sales order
-        const sales_order = sales_orders[0];
-        frappe.db.get_doc('Sales Order', sales_order).then(so => {
-            // Set fields from Sales Order
-            frm.set_value('custom_consignee_name', so.customer_name);
-            frm.set_value('custom_consignee_address_', so.address_display);
-            
-            // Fetch and set Address details
-            if (so.shipping_address_name) {
-                frappe.db.get_doc('Address', so.shipping_address_name).then(addr => {
-                    frm.set_value('custom_consignee_city', addr.city || '');
-                    frm.set_value('custom_consignee_country', addr.country || '');
-                    frm.set_value('custom_consignee_state', addr.state || addr.state_or_province || '');
-                    frm.set_value('custom_consignee_postal_code', addr.pincode || '');
-                    frm.set_value('custom_consignee_contact', addr.phone || '');
+    // Use the first available sales order
+    const sales_order = sales_orders[0];
+    frappe.db.get_doc('Sales Order', sales_order).then(so => {
+        // Set fields from Sales Order
+        frm.set_value('custom_consignee_name', so.customer_name);
 
-                    frm.refresh_fields();
-                });
-            }
-        });
-    }
+        // Convert HTML address_display to plain text
+        const tempDiv = document.createElement('div');
+        tempDiv.innerHTML = so.address_display || '';
+        const plainAddress = tempDiv.textContent || tempDiv.innerText || '';
+        frm.set_value('custom_consignee_address_', plainAddress);
+
+        // Fetch and set Address details
+        if (so.shipping_address_name) {
+            frappe.db.get_doc('Address', so.shipping_address_name).then(addr => {
+                frm.set_value('custom_consignee_city', addr.city || '');
+                frm.set_value('custom_consignee_country', addr.country || '');
+                frm.set_value('custom_consignee_state', addr.state || addr.state_or_province || '');
+                frm.set_value('custom_consignee_postal_code', addr.pincode || '');
+                frm.set_value('custom_consignee_contact', addr.phone || '');
+
+                frm.refresh_fields();
+            });
+        }
+    });
+}
         
 })     
              


### PR DESCRIPTION
Fix: Removed HTML tags from Consignee Address

Previously, the Consignee Address field was displaying values with HTML tags. This has been resolved by stripping out the HTML, so the address now appears in plain text format.
